### PR TITLE
tlmgrを更新してから日本語パッケージを導入

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
             --entrypoint sh \
             pandoc/latex:latest \
             -c '
+              tlmgr update --self &&
               tlmgr install collection-langjapanese &&
               pandoc constitution.md \
                 --pdf-engine=lualatex \


### PR DESCRIPTION
## 変更内容

- 日本語TeXパッケージを導入する前に `tlmgr update --self` を実行

## 理由

`pandoc/latex:latest` 内の `tlmgr` がリポジトリより古く、`collection-langjapanese` のインストールが終了コード255で失敗していました。

## 確認

- `actionlint` 成功
- `git diff --check` 成功
